### PR TITLE
feat: make it clear when an invalid instance is created

### DIFF
--- a/src/nibbles.rs
+++ b/src/nibbles.rs
@@ -277,6 +277,7 @@ impl Nibbles {
     /// let nibbles = Nibbles::from_vec(vec![0xFF]);
     /// ```
     #[inline]
+    #[track_caller]
     pub fn from_vec(vec: Vec<u8>) -> Self {
         if !vec.iter().all(|&x| x <= 0xf) {
             panic_invalid_nibbles();
@@ -675,7 +676,7 @@ impl Nibbles {
     #[track_caller]
     pub fn set_at(&mut self, i: usize, value: u8) {
         assert!(value <= 0xf);
-        self.0[i] = value;
+        self.set_at_unchecked(i, value);
     }
 
     /// Sets the nibble at the given index, without checking its validity.


### PR DESCRIPTION
- remove `From<Vec<u8>>` impl in favor of `from_vec_unchecked` method
- remove `Extend` impl in favor of `extend_from*` methods
- allow unchecked access to underlying `SmallVec`
- add "safe" counterparts to `_unchecked` that check validity of nibbles, and viceversa add missing checks and unchecked versions
- update docs to use safe versions, add examples of bad usage