### PR TITLE
feat: improve benchmarks, compare with naive implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [aarch64-unknown-linux-gnu, i686-unknown-linux-gnu, x86_64-unknown-linux-gnu]
-        rust: [nightly, stable, 1.64]
+        rust: [nightly, stable, 1.64] # MSRV
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -45,8 +45,10 @@ jobs:
 
       - run: cargo build
       - run: cargo test
+        if: matrix.rust != '1.64' # MSRV
       - run: cargo build --no-default-features
       - run: cargo test --tests --no-default-features
+        if: matrix.rust != '1.64' # MSRV
 
   miri:
     name: Miri


### PR DESCRIPTION
```julia
unpack/naive/16         time:   [13.755 ns 13.823 ns 13.915 ns]
                        thrpt:  [1.0709 GiB/s 1.0780 GiB/s 1.0833 GiB/s]
unpack/nybbles/16       time:   [6.7940 ns 6.8229 ns 6.8531 ns]
                        thrpt:  [2.1744 GiB/s 2.1840 GiB/s 2.1933 GiB/s]
unpack/naive/32         time:   [18.061 ns 18.090 ns 18.136 ns]
                        thrpt:  [1.6432 GiB/s 1.6474 GiB/s 1.6501 GiB/s]
unpack/nybbles/32       time:   [7.3837 ns 7.4095 ns 7.4364 ns]
                        thrpt:  [4.0076 GiB/s 4.0222 GiB/s 4.0363 GiB/s]
unpack/naive/256        time:   [11.919 ns 11.971 ns 12.045 ns]
                        thrpt:  [19.795 GiB/s 19.917 GiB/s 20.003 GiB/s]
unpack/nybbles/256      time:   [8.7785 ns 8.7991 ns 8.8384 ns]
                        thrpt:  [26.975 GiB/s 27.096 GiB/s 27.159 GiB/s]
unpack/naive/2048       time:   [50.859 ns 51.687 ns 52.679 ns]
                        thrpt:  [36.207 GiB/s 36.902 GiB/s 37.502 GiB/s]
unpack/nybbles/2048     time:   [43.162 ns 43.250 ns 43.348 ns]
                        thrpt:  [44.001 GiB/s 44.101 GiB/s 44.190 GiB/s]

pack/naive/16           time:   [11.216 ns 11.256 ns 11.297 ns]
                        thrpt:  [1.3190 GiB/s 1.3238 GiB/s 1.3286 GiB/s]
pack/nybbles/16         time:   [7.3448 ns 7.3563 ns 7.3698 ns]
                        thrpt:  [2.0219 GiB/s 2.0256 GiB/s 2.0288 GiB/s]
pack/naive/32           time:   [14.369 ns 14.397 ns 14.428 ns]
                        thrpt:  [2.0656 GiB/s 2.0700 GiB/s 2.0740 GiB/s]
pack/nybbles/32         time:   [6.0482 ns 6.0665 ns 6.0816 ns]
                        thrpt:  [4.9004 GiB/s 4.9126 GiB/s 4.9275 GiB/s]
pack/naive/256          time:   [54.426 ns 54.539 ns 54.667 ns]
                        thrpt:  [4.3613 GiB/s 4.3716 GiB/s 4.3806 GiB/s]
pack/nybbles/256        time:   [10.402 ns 10.427 ns 10.455 ns]
                        thrpt:  [22.805 GiB/s 22.865 GiB/s 22.921 GiB/s]
pack/naive/2048         time:   [345.58 ns 346.20 ns 346.97 ns]
                        thrpt:  [5.4972 GiB/s 5.5095 GiB/s 5.5193 GiB/s]
pack/nybbles/2048       time:   [25.150 ns 25.190 ns 25.241 ns]
                        thrpt:  [75.566 GiB/s 75.718 GiB/s 75.838 GiB/s]

encode_path_leaf/nybbles/16
                        time:   [7.4174 ns 7.4405 ns 7.4683 ns]
                        thrpt:  [1.9952 GiB/s 2.0027 GiB/s 2.0090 GiB/s]
encode_path_leaf/nybbles/32
                        time:   [8.5738 ns 8.6283 ns 8.6907 ns]
                        thrpt:  [3.4292 GiB/s 3.4540 GiB/s 3.4760 GiB/s]
encode_path_leaf/nybbles/256
                        time:   [14.774 ns 14.891 ns 15.020 ns]
                        thrpt:  [15.873 GiB/s 16.011 GiB/s 16.138 GiB/s]
encode_path_leaf/nybbles/2048
                        time:   [23.542 ns 23.572 ns 23.601 ns]
                        thrpt:  [80.816 GiB/s 80.916 GiB/s 81.019 GiB/s]
```