### PR TITLE
feat: add more raw APIs for working with slices directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,18 +13,27 @@ repository = "https://github.com/alloy-rs/nybbles"
 exclude = [".github/", "deny.toml", "release.toml", "rustfmt.toml"]
 
 [dependencies]
-smallvec = { version = "1.0", default-features = false, features = ["const_new", "union"] }
+smallvec = { version = "1.0", default-features = false, features = [
+    "const_new",
+    "union",
+] }
 const-hex = { version = "1.10", default-features = false, features = ["alloc"] }
 
 # serde
-serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
+serde = { version = "1.0", default-features = false, optional = true, features = [
+    "derive",
+] }
 
 # rlp
 alloy-rlp = { version = "0.3", default-features = false, optional = true }
 
 # arbitrary
-arbitrary = { version = "1.3", default-features = false, optional = true, features = ["derive"] }
-proptest = { version = "1.4", default-features = false, optional = true, features = ["alloc"] }
+arbitrary = { version = "1.3", default-features = false, optional = true, features = [
+    "derive",
+] }
+proptest = { version = "1.4", default-features = false, optional = true, features = [
+    "alloc",
+] }
 
 [dev-dependencies]
 hex-literal = "0.4"
@@ -33,6 +42,7 @@ criterion = "0.5"
 [features]
 default = ["std"]
 std = ["const-hex/std", "serde?/std", "alloy-rlp?/std", "proptest?/std"]
+nightly = ["smallvec/specialization", "smallvec/may_dangle"]
 serde = ["dep:serde", "smallvec/serde"]
 rlp = ["dep:alloy-rlp"]
 arbitrary = ["dep:arbitrary", "dep:proptest", "smallvec/arbitrary", "std"]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -42,7 +42,7 @@ pub fn nibbles_benchmark(c: &mut Criterion) {
             let id = criterion::BenchmarkId::new("nybbles", len);
             g.bench_function(id, |b| {
                 let bytes = &get_nibbles(len as usize);
-                b.iter(|| black_box(&bytes).pack())
+                b.iter(|| black_box(bytes).pack())
             });
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,13 @@
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(feature = "nightly", feature(core_intrinsics), allow(internal_features))]
 
 #[macro_use]
 #[allow(unused_imports)]
 extern crate alloc;
 
 mod nibbles;
-pub use nibbles::Nibbles;
+pub use nibbles::{
+    common_prefix_length, get_byte, get_byte_unchecked, pack_to, pack_to_unchecked, Nibbles,
+};


### PR DESCRIPTION
Plus some refactoring to unify `_stack` & `_heap` methods. `SmallVec::with_capacity` + `set_len` unfortunately codegens a bit worse than manually branching and constructing.