### PR TITLE
chore: better debug impl

### DIFF
--- a/src/nibbles.rs
+++ b/src/nibbles.rs
@@ -75,7 +75,7 @@ impl Clone for Nibbles {
 impl fmt::Debug for Nibbles {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("Nibbles").field(&const_hex::encode(self.as_slice())).finish()
+        write!(f, "Nibbles(0x{})", const_hex::encode(self.as_slice()))
     }
 }
 


### PR DESCRIPTION
- use 0x
- manually write the tuple so it doesn't spill on 3 lines on {:#?} and so it doesn't add quotes ""