### PR TITLE
fix: bump minimum ruint version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ smallvec = { version = "1.0", default-features = false, features = [
     "const_new",
     "union",
 ] }
-ruint = { version = "1", default-features = false, features = ["alloc"] }
+ruint = { version = "1.15.0", default-features = false, features = ["alloc"] }
 
 # serde
 serde = { version = "1.0", default-features = false, optional = true, features = [


### PR DESCRIPTION
This library requires const `wrapping_shl`:
https://github.com/alloy-rs/nybbles/blob/53ed26602250b3dc66753c439efda21b33fcc460/src/nibbles.rs#L36

This is only available in ruint >= 1.15.0.