### PR TITLE
feat: Add back support for big-endian targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,31 @@ jobs:
       - run: cargo test --all-features
         if: matrix.rust == 'nightly'
 
+  test-be:
+    name: Test Big-Endian
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [mips-unknown-linux-gnu, mips64-unknown-linux-gnuabi64]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+
+      - name: Enable type layout randomization
+        run: echo RUSTFLAGS=${RUSTFLAGS}\ -Zrandomize-layout >> $GITHUB_ENV
+
+      - uses: Swatinem/rust-cache@v2
+
+      - run: cargo build -Zbuild-std
+      - run: cargo test -Zbuild-std
+      - run: cargo build --no-default-features -Zbuild-std
+      - run: cargo test --no-default-features -Zbuild-std
+
   miri:
     name: miri ${{ matrix.flags }}
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ smallvec = { version = "1.0", default-features = false, features = [
     "union",
 ] }
 ruint = { version = "1.15.0", default-features = false, features = ["alloc"] }
+cfg-if = "1.0"
 
 # serde
 serde = { version = "1.0", default-features = false, optional = true, features = [


### PR DESCRIPTION
## Overview

Adds back big-endian support after https://github.com/alloy-rs/nybbles/pull/17, cc @shekhirin 

These changes should have no impact on the performance of this crate when targeting little-endian - All methods that require read-only access to the underlying `U256` can use [`as_le_bytes`](https://docs.rs/ruint/latest/ruint/struct.Uint.html#method.as_le_bytes), and methods that relied on `as_le_slice_mut` retain the existing implementation when `cfg(target_endian = "little")`.

Also adds a new CI job to build/test the crate on big-endian 32-bit and 64-bit MIPS targets.


### Meta

closes #31 