### PR TITLE
feat: add iterator for Nibbles

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,4 +22,4 @@
 extern crate alloc;
 
 mod nibbles;
-pub use nibbles::{smallvec_with, Nibbles};
+pub use nibbles::{smallvec_with, Nibbles, NibblesIter};

--- a/src/nibbles.rs
+++ b/src/nibbles.rs
@@ -458,11 +458,7 @@ impl Nibbles {
     /// assert_eq!(nibbles.to_vec(), vec![0x0A, 0x0B, 0x0C, 0x0D]);
     /// ```
     pub fn to_vec(&self) -> Vec<u8> {
-        let mut nibbles = Vec::with_capacity(self.len());
-        for i in 0..self.len() {
-            nibbles.push(self.get_checked(i));
-        }
-        nibbles
+        self.iter().collect()
     }
 
     /// Returns an iterator over the nibbles.

--- a/src/nibbles.rs
+++ b/src/nibbles.rs
@@ -460,9 +460,24 @@ impl Nibbles {
     pub fn to_vec(&self) -> Vec<u8> {
         let mut nibbles = Vec::with_capacity(self.len());
         for i in 0..self.len() {
-            nibbles.push(self.get_unchecked(i));
+            nibbles.push(self.get_checked(i));
         }
         nibbles
+    }
+
+    /// Returns an iterator over the nibbles.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use nybbles::Nibbles;
+    /// let nibbles = Nibbles::from_nibbles(&[0x0A, 0x0B, 0x0C, 0x0D]);
+    /// let collected: Vec<u8> = nibbles.iter().collect();
+    /// assert_eq!(collected, vec![0x0A, 0x0B, 0x0C, 0x0D]);
+    /// ```
+    #[inline]
+    pub const fn iter(&self) -> NibblesIter<'_> {
+        NibblesIter { current: 0, nibbles: self }
     }
 
     /// Gets the byte at the given index by combining two consecutive nibbles.
@@ -600,6 +615,17 @@ impl Nibbles {
     #[track_caller]
     pub fn get_unchecked(&self, i: usize) -> u8 {
         self.assert_index(i);
+        self.get_checked(i)
+    }
+
+    /// Returns the nibble at the given index.
+    ///
+    /// Caution: This expects that the index is valid
+    ///
+    /// Panics if the index is out of bounds.
+    #[inline]
+    #[track_caller]
+    fn get_checked(&self, i: usize) -> u8 {
         let byte = as_le_slice(&self.nibbles)[U256::BYTES - i / 2 - 1];
         if i % 2 == 0 {
             byte >> 4
@@ -964,6 +990,55 @@ impl Nibbles {
         if i >= len {
             panic_invalid_index(len, i);
         }
+    }
+}
+
+/// Iterator over individual nibbles within a [`Nibbles`] structure.
+///
+/// This iterator provides efficient access to each nibble in sequence,
+/// using unchecked access for performance.
+///
+/// # Examples
+///
+/// ```
+/// # use nybbles::Nibbles;
+/// let nibbles = Nibbles::from_nibbles(&[0x0A, 0x0B, 0x0C, 0x0D]);
+/// let collected: Vec<u8> = nibbles.iter().collect();
+/// assert_eq!(collected, vec![0x0A, 0x0B, 0x0C, 0x0D]);
+/// ```
+#[derive(Debug, Clone)]
+pub struct NibblesIter<'a> {
+    /// Current position in the iteration.
+    current: usize,
+    /// Reference to the nibbles being iterated over.
+    nibbles: &'a Nibbles,
+}
+
+impl<'a> Iterator for NibblesIter<'a> {
+    type Item = u8;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current < self.nibbles.len() {
+            let nibble = self.nibbles.get_checked(self.current);
+            self.current += 1;
+            Some(nibble)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.nibbles.len() - self.current;
+        (remaining, Some(remaining))
+    }
+}
+
+impl<'a> ExactSizeIterator for NibblesIter<'a> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.nibbles.len() - self.current
     }
 }
 
@@ -1668,6 +1743,63 @@ mod tests {
             Nibbles::from_nibbles([0x1, 0x2, 0x3, 0xF, 0xF]).increment().unwrap(),
             Nibbles::from_nibbles([0x1, 0x2, 0x4, 0x0, 0x0])
         );
+    }
+
+    #[test]
+    fn iter() {
+        // Test empty nibbles
+        let empty = Nibbles::new();
+        assert_eq!(empty.iter().collect::<Vec<_>>(), vec![]);
+
+        // Test basic iteration
+        let nibbles = Nibbles::from_nibbles(&[0x0A, 0x0B, 0x0C, 0x0D]);
+        let collected: Vec<u8> = nibbles.iter().collect();
+        assert_eq!(collected, vec![0x0A, 0x0B, 0x0C, 0x0D]);
+
+        // Test that iter() produces same result as to_vec()
+        assert_eq!(nibbles.iter().collect::<Vec<_>>(), nibbles.to_vec());
+
+        // Test single nibble
+        let single = Nibbles::from_nibbles(&[0x05]);
+        assert_eq!(single.iter().collect::<Vec<_>>(), vec![0x05]);
+
+        // Test odd number of nibbles
+        let odd = Nibbles::from_nibbles(&[0x01, 0x02, 0x03]);
+        assert_eq!(odd.iter().collect::<Vec<_>>(), vec![0x01, 0x02, 0x03]);
+
+        // Test max length nibbles
+        let max_nibbles: Vec<u8> = (0..64).map(|i| (i % 16) as u8).collect();
+        let max = Nibbles::from_nibbles(&max_nibbles);
+        assert_eq!(max.iter().collect::<Vec<_>>(), max_nibbles);
+
+        // Test iterator size_hint and len
+        let nibbles = Nibbles::from_nibbles(&[0x0A, 0x0B, 0x0C, 0x0D]);
+        let mut iter = nibbles.iter();
+        assert_eq!(iter.len(), 4);
+        assert_eq!(iter.size_hint(), (4, Some(4)));
+
+        iter.next();
+        assert_eq!(iter.len(), 3);
+        assert_eq!(iter.size_hint(), (3, Some(3)));
+
+        iter.next();
+        iter.next();
+        assert_eq!(iter.len(), 1);
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+
+        iter.next();
+        assert_eq!(iter.len(), 0);
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+        assert_eq!(iter.next(), None);
+
+        // Test cloning iterator
+        let nibbles = Nibbles::from_nibbles(&[0x01, 0x02, 0x03, 0x04]);
+        let mut iter1 = nibbles.iter();
+        iter1.next();
+        let iter2 = iter1.clone();
+
+        assert_eq!(iter1.collect::<Vec<_>>(), vec![0x02, 0x03, 0x04]);
+        assert_eq!(iter2.collect::<Vec<_>>(), vec![0x02, 0x03, 0x04]);
     }
 
     #[cfg(feature = "arbitrary")]

--- a/src/nibbles.rs
+++ b/src/nibbles.rs
@@ -1030,8 +1030,8 @@ impl<'a> Iterator for NibblesIter<'a> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.nibbles.len() - self.current;
-        (remaining, Some(remaining))
+        let len = self.len();
+        (len, Some(len))
     }
 }
 

--- a/src/nibbles.rs
+++ b/src/nibbles.rs
@@ -1004,13 +1004,7 @@ impl<'a> Iterator for NibblesIter<'a> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        if self.current < self.nibbles.len() {
-            let nibble = self.nibbles.get_unchecked(self.current);
-            self.current += 1;
-            Some(nibble)
-        } else {
-            None
-        }
+        self.nibbles.get(self.current).inspect(|_| self.current += 1)
     }
 
     #[inline]

--- a/src/nibbles.rs
+++ b/src/nibbles.rs
@@ -1752,7 +1752,7 @@ mod tests {
         assert_eq!(empty.iter().collect::<Vec<_>>(), vec![]);
 
         // Test basic iteration
-        let nibbles = Nibbles::from_nibbles(&[0x0A, 0x0B, 0x0C, 0x0D]);
+        let nibbles = Nibbles::from_nibbles([0x0A, 0x0B, 0x0C, 0x0D]);
         let collected: Vec<u8> = nibbles.iter().collect();
         assert_eq!(collected, vec![0x0A, 0x0B, 0x0C, 0x0D]);
 
@@ -1760,11 +1760,11 @@ mod tests {
         assert_eq!(nibbles.iter().collect::<Vec<_>>(), nibbles.to_vec());
 
         // Test single nibble
-        let single = Nibbles::from_nibbles(&[0x05]);
+        let single = Nibbles::from_nibbles([0x05]);
         assert_eq!(single.iter().collect::<Vec<_>>(), vec![0x05]);
 
         // Test odd number of nibbles
-        let odd = Nibbles::from_nibbles(&[0x01, 0x02, 0x03]);
+        let odd = Nibbles::from_nibbles([0x01, 0x02, 0x03]);
         assert_eq!(odd.iter().collect::<Vec<_>>(), vec![0x01, 0x02, 0x03]);
 
         // Test max length nibbles
@@ -1773,7 +1773,7 @@ mod tests {
         assert_eq!(max.iter().collect::<Vec<_>>(), max_nibbles);
 
         // Test iterator size_hint and len
-        let nibbles = Nibbles::from_nibbles(&[0x0A, 0x0B, 0x0C, 0x0D]);
+        let nibbles = Nibbles::from_nibbles([0x0A, 0x0B, 0x0C, 0x0D]);
         let mut iter = nibbles.iter();
         assert_eq!(iter.len(), 4);
         assert_eq!(iter.size_hint(), (4, Some(4)));
@@ -1793,7 +1793,7 @@ mod tests {
         assert_eq!(iter.next(), None);
 
         // Test cloning iterator
-        let nibbles = Nibbles::from_nibbles(&[0x01, 0x02, 0x03, 0x04]);
+        let nibbles = Nibbles::from_nibbles([0x01, 0x02, 0x03, 0x04]);
         let mut iter1 = nibbles.iter();
         iter1.next();
         let iter2 = iter1.clone();

--- a/src/nibbles.rs
+++ b/src/nibbles.rs
@@ -611,17 +611,6 @@ impl Nibbles {
     #[track_caller]
     pub fn get_unchecked(&self, i: usize) -> u8 {
         self.assert_index(i);
-        self.get_checked(i)
-    }
-
-    /// Returns the nibble at the given index.
-    ///
-    /// Caution: This expects that the index is valid
-    ///
-    /// Panics if the index is out of bounds.
-    #[inline]
-    #[track_caller]
-    fn get_checked(&self, i: usize) -> u8 {
         let byte = as_le_slice(&self.nibbles)[U256::BYTES - i / 2 - 1];
         if i % 2 == 0 {
             byte >> 4
@@ -1016,7 +1005,7 @@ impl<'a> Iterator for NibblesIter<'a> {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.current < self.nibbles.len() {
-            let nibble = self.nibbles.get_checked(self.current);
+            let nibble = self.nibbles.get_unchecked(self.current);
             self.current += 1;
             Some(nibble)
         } else {


### PR DESCRIPTION
Implements an iterator type for the Nibbles struct that behaves similarly to `to_vec()` but provides lazy iteration over nibbles.

The iterator yields nibbles by iterating from 0 to self.len() using internal unchecked access for performance.

## Changes
- Added `NibblesIter` struct with lifetime bounds
- Implemented `Iterator` and `ExactSizeIterator` traits
- Added `iter()` method to Nibbles struct
- Added comprehensive test coverage for the iterator
- Exported `NibblesIter` from lib.rs

Closes #33