### PR TITLE
fix: `pack_to_unchecked` on big-endian targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flags: ["--no-default-features", "", "--all-features"]
+        flags: ["--no-default-features", "", "--all-features", "--target mips64-unknown-linux-gnuabi64"]
     env:
       MIRIFLAGS: -Zmiri-strict-provenance
     steps:

--- a/src/nibbles.rs
+++ b/src/nibbles.rs
@@ -1031,7 +1031,8 @@ unsafe fn pack_to_unchecked(nibbles: &Nibbles, out: &mut [MaybeUninit<u8>]) {
     let byte_len = nibbles.len().div_ceil(2);
     debug_assert!(out.len() >= byte_len);
     // Move source pointer to the end of the little endian slice
-    let mut src = as_le_slice(&nibbles.nibbles).as_ptr().add(U256::BYTES);
+    let sl = as_le_slice(&nibbles.nibbles);
+    let mut src = sl.as_ptr().add(U256::BYTES);
     // Destination pointer is at the beginning of the output slice
     let mut dst = out.as_mut_ptr().cast::<u8>();
     // On each iteration, decrement the source pointer by one, set the destination byte, and


### PR DESCRIPTION
## Overview

Fixes an issue for big-endian targets that was introduced by #32, where the temporary value created by `as_le_slice` was dropped immediately after the expression is evaluated. This change extends the lifetime of the `Owned` variant.

Repro (run miri): https://play.rust-lang.org/?version=stable&mode=release&edition=2024&gist=b92df156a14b6af538531bd8e3d28923