### PR TITLE
change debug_assert!() to assert!() in Nibbles::len()

### DIFF
--- a/src/nibbles.rs
+++ b/src/nibbles.rs
@@ -805,7 +805,7 @@ impl Nibbles {
     #[inline]
     pub const fn len(&self) -> usize {
         let len = self.len;
-        debug_assert!(len <= NIBBLES);
+        assert!(len <= NIBBLES);
         unsafe { core::hint::assert_unchecked(len <= NIBBLES) };
         len
     }


### PR DESCRIPTION
This PR addresses the soundness issue  #56  mentioned in this issue. As this issue mentioned, when using `cargo miri run --release` to test that POC, miri will skip the debug_assert!() and trigger undefined behaviour in `unsafe { core::hint::assert_unchecked(len <= NIBBLES) }`. So the minimal solution is change the debug_assert!() to assert!().